### PR TITLE
feat: zsh: Add Undo hack

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -77,6 +77,7 @@ source_config "inc.atuin.zsh"
 source_config "inc.gcloud.zsh"
 source_config "inc.ansible.zsh"
 source_config "inc.neovim.zsh"
+source_config "inc.undo.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/inc.undo.zsh
+++ b/zsh/inc.undo.zsh
@@ -1,0 +1,20 @@
+# Undo in Zsh Command Buffer
+# Zsh has an undo feature that can revert the last action taken in the command
+# buffer, useful for accidental deletions or changes.
+#
+# Usage: Press Ctrl + _ (Control and underscore) to undo
+#        The undo widget is already bound by default in Zsh
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (1:48-2:38)
+
+# Note: The undo widget is already available by default in Zsh
+# Default keybindings:
+#   - Ctrl + _ (Emacs mode)
+#   - u (vi command mode)
+#
+# You can also bind it to other keys if desired:
+# bindkey '^Z' undo
+# bindkey '^[u' undo  # Alt+u
+
+# For visibility, we'll ensure the default binding is set
+bindkey '^_' undo


### PR DESCRIPTION
## Summary

Adds documentation and ensures the undo keybinding is properly set. Zsh has a built-in undo feature that can revert the last action in the command buffer, useful for accidental deletions or changes.

## What it achieves

- Allows you to undo the last edit in the command line
- Useful for recovering from accidental deletions or modifications
- Multiple undo operations can be performed to step back through changes

## Zsh Configuration

```zsh
bindkey '^_' undo
```

**Default keybindings:** Emacs mode: `Ctrl + _` (or `Ctrl + /`) | Vi command mode: `u`

## Reference

- **Original video**: [10 Zsh Tips to Improve Productivity (1:48-2:38)](https://www.youtube.com/watch?v=3fVAtaGhUyU)

## Additional Applications & Inspiration

- [A User's Guide to the Z-Shell - Chapter 4](https://zsh.sourceforge.io/Guide/zshguide04.html)
- [QuarticCat's Blog: Some useful Zsh key-bindings](https://blog.quarticcat.com/posts/some-useful-zsh-key-bindings/)
- [Gist: Cmd-Z -> Undo, Cmd-Shift-Z -> Redo in zsh](https://gist.github.com/ToQoz/8571106)
- [CLI Notes: Preview (and undo) command line expansions](https://postgresqlstan.github.io/zsh/zsh-undo/)
- [Mastering Zsh: Bindkey Guide](https://github.com/rothgar/mastering-zsh/blob/master/docs/helpers/bindkey.md)
- [Gist: Keyboard shortcuts for bash/zsh](https://gist.github.com/2KAbhishek/9c6d607e160b0439a186d4fbd1bd81df)