### PR TITLE
feat: zsh: Add Named Directories hack

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -81,6 +81,7 @@ source_config "inc.edit-command-line.zsh"
 source_config "inc.undo.zsh"
 source_config "inc.magic-space.zsh"
 source_config "inc.chpwd.zsh"
+source_config "inc.suffix-aliases.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -83,6 +83,7 @@ source_config "inc.magic-space.zsh"
 source_config "inc.chpwd.zsh"
 source_config "inc.suffix-aliases.zsh"
 source_config "inc.global-aliases.zsh"
+source_config "inc.zmv.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -78,6 +78,7 @@ source_config "inc.gcloud.zsh"
 source_config "inc.ansible.zsh"
 source_config "inc.neovim.zsh"
 source_config "inc.edit-command-line.zsh"
+source_config "inc.undo.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -79,6 +79,7 @@ source_config "inc.ansible.zsh"
 source_config "inc.neovim.zsh"
 source_config "inc.edit-command-line.zsh"
 source_config "inc.undo.zsh"
+source_config "inc.magic-space.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -80,6 +80,7 @@ source_config "inc.neovim.zsh"
 source_config "inc.edit-command-line.zsh"
 source_config "inc.undo.zsh"
 source_config "inc.magic-space.zsh"
+source_config "inc.chpwd.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -77,6 +77,7 @@ source_config "inc.atuin.zsh"
 source_config "inc.gcloud.zsh"
 source_config "inc.ansible.zsh"
 source_config "inc.neovim.zsh"
+source_config "inc.edit-command-line.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -82,6 +82,7 @@ source_config "inc.undo.zsh"
 source_config "inc.magic-space.zsh"
 source_config "inc.chpwd.zsh"
 source_config "inc.suffix-aliases.zsh"
+source_config "inc.global-aliases.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -84,6 +84,7 @@ source_config "inc.chpwd.zsh"
 source_config "inc.suffix-aliases.zsh"
 source_config "inc.global-aliases.zsh"
 source_config "inc.zmv.zsh"
+source_config "inc.named-directories.zsh"
 source_config "inc.tmux.zsh"
 
 source_config "inc.git.zsh"

--- a/zsh/inc.chpwd.zsh
+++ b/zsh/inc.chpwd.zsh
@@ -1,0 +1,56 @@
+# chpwd hook
+# Allows you to execute a command automatically whenever you change into a
+# different directory. This can be used for various purposes like loading
+# Nix develop shells, activating Python virtual environments, or managing
+# Node.js versions with nvm.
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (4:03-6:03)
+
+# The chpwd function (and chpwd_functions array) is called after every
+# directory change. You can define multiple functions and add them to the
+# chpwd_functions array, or use add-zsh-hook to add them.
+
+# Example 1: List directory contents on every directory change
+# Uncomment to enable:
+# chpwd_ls() {
+#     ls -lah
+# }
+# chpwd_functions=(${chpwd_functions[@]} "chpwd_ls")
+
+# Example 2: Show git status when entering a git repository
+# Uncomment to enable:
+# chpwd_git_status() {
+#     if [[ -d .git ]]; then
+#         git status -sb
+#     fi
+# }
+# chpwd_functions=(${chpwd_functions[@]} "chpwd_git_status")
+
+# Example 3: Auto-activate Python virtual environments
+# Uncomment to enable:
+# chpwd_python_venv() {
+#     # Deactivate any current virtual environment
+#     if [[ -n "$VIRTUAL_ENV" ]]; then
+#         deactivate 2>/dev/null
+#     fi
+#
+#     # Look for a virtual environment in common locations
+#     for venv_dir in venv .venv env .env; do
+#         if [[ -f "$venv_dir/bin/activate" ]]; then
+#             source "$venv_dir/bin/activate"
+#             echo "Activated Python virtual environment: $venv_dir"
+#             break
+#         fi
+#     done
+# }
+# chpwd_functions=(${chpwd_functions[@]} "chpwd_python_venv")
+
+# Example 4: Using add-zsh-hook (alternative method)
+# This is cleaner for adding hooks programmatically
+# autoload -Uz add-zsh-hook
+# add-zsh-hook chpwd chpwd_ls
+
+# Note: Some tools like direnv already use chpwd hooks, so be careful
+# not to create conflicts with existing directory-based tools.
+
+# Add your own custom chpwd functions below:

--- a/zsh/inc.edit-command-line.zsh
+++ b/zsh/inc.edit-command-line.zsh
@@ -1,0 +1,17 @@
+# Edit Command Buffer in $EDITOR
+# Allows you to open the current command buffer in your configured text editor
+# (e.g., Neovim) to easily correct mistakes or modify long commands using
+# your editor's keybindings.
+#
+# Usage: Press Ctrl+X Ctrl+E to open the current command line in your editor
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (0:41-1:47)
+
+# Load the edit-command-line widget
+autoload -Uz edit-command-line
+
+# Create a ZLE widget from the function
+zle -N edit-command-line
+
+# Bind Ctrl+X Ctrl+E to edit the command line
+bindkey '^X^E' edit-command-line

--- a/zsh/inc.global-aliases.zsh
+++ b/zsh/inc.global-aliases.zsh
@@ -1,0 +1,77 @@
+# Global Aliases
+# These aliases can be used anywhere within a command, not just at the start,
+# allowing you to define commonly used arguments or parameters as simple shortcuts.
+#
+# Usage: Type the alias anywhere in your command line
+#
+# Example: ls -la NE  →  ls -la 2>/dev/null
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (9:22-11:04)
+#
+# Note: It's recommended to use UPPERCASE names for global aliases to prevent
+#       accidental expansion and make them more visible.
+
+# Redirect stderr to /dev/null (silence errors)
+alias -g NE='2>/dev/null'
+
+# Redirect stdout to /dev/null (silence output)
+alias -g NUL='>/dev/null 2>&1'
+
+# Pipe to grep
+alias -g G='| grep'
+alias -g GI='| grep -i'  # case-insensitive grep
+
+# Pipe to less
+alias -g L='| less'
+
+# Pipe to head/tail
+alias -g H='| head'
+alias -g T='| tail'
+
+# Pipe to wc (word count)
+alias -g WC='| wc -l'
+
+# Pipe to sort
+alias -g S='| sort'
+alias -g SN='| sort -n'  # numeric sort
+alias -g SR='| sort -r'  # reverse sort
+
+# Pipe to uniq
+alias -g U='| uniq'
+
+# Pipe to awk/sed
+alias -g A='| awk'
+alias -g SE='| sed'
+
+# Pipe to xargs
+alias -g X='| xargs'
+
+# Pipe to column for table formatting
+alias -g C='| column -t'
+
+# Copy to clipboard (platform-specific)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias -g CLIP='| pbcopy'
+elif command -v xclip &> /dev/null; then
+    alias -g CLIP='| xclip -selection clipboard'
+elif command -v xsel &> /dev/null; then
+    alias -g CLIP='| xsel --clipboard'
+fi
+
+# JSON pretty-print (if jq is available)
+if command -v jq &> /dev/null; then
+    alias -g JSON='| jq .'
+    alias -g JSONC='| jq -C .'  # colored output
+fi
+
+# First/Last items
+alias -g FIRST='| head -1'
+alias -g LAST='| tail -1'
+
+# Count occurrences
+alias -g COUNT='| sort | uniq -c | sort -rn'
+
+# Remove empty lines
+alias -g NONEMPTY='| grep -v "^$"'
+
+# Add your own custom global aliases below:

--- a/zsh/inc.magic-space.zsh
+++ b/zsh/inc.magic-space.zsh
@@ -1,0 +1,18 @@
+# Magic Space
+# Expands historical commands or references to show their full content before
+# execution, preventing accidental runs of unknown commands.
+#
+# Usage: Type a history expansion (like !!, !$, !*, etc.) and press Space
+#        The expansion will be replaced with the actual command
+#
+# Example: Type "sudo !!" and press Space - the !! will expand to show
+#          the previous command instead of executing blindly
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (2:39-4:02)
+
+# Bind the magic-space widget to the space key
+# This performs history expansion when you press space
+bindkey ' ' magic-space
+
+# You can also keep the normal space behavior for other uses:
+# bindkey '^[' magic-space  # Use Alt+Space for magic-space instead

--- a/zsh/inc.named-directories.zsh
+++ b/zsh/inc.named-directories.zsh
@@ -1,0 +1,43 @@
+# Named Directories
+# Allows you to bookmark frequently used directories with short aliases for
+# quick navigation or referencing in commands.
+#
+# Usage: cd ~alias_name  or  ls ~alias_name
+#
+# Example: hash -d proj=~/Projects
+#          cd ~proj  →  cd ~/Projects
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (13:08-14:04)
+
+# Home directory shortcuts (commented out - uncomment and customize as needed)
+# hash -d docs=~/Documents
+# hash -d dl=~/Downloads
+# hash -d dt=~/Desktop
+# hash -d pics=~/Pictures
+# hash -d vids=~/Videos
+# hash -d music=~/Music
+
+# Development project shortcuts (commented out - uncomment and customize)
+# hash -d proj=~/Projects
+# hash -d dev=~/Development
+# hash -d code=~/Code
+# hash -d git=~/git
+# hash -d repos=~/repositories
+
+# Configuration shortcuts (commented out - uncomment and customize)
+# hash -d dotfiles=~/.dotfiles
+# hash -d config=~/.config
+# hash -d nvim=~/.config/nvim
+# hash -d zsh=~/.config/zsh
+
+# Work-related shortcuts (commented out - uncomment and customize)
+# hash -d work=~/Work
+# hash -d notes=~/Notes
+
+# Tips:
+# - Named directories work with tab completion
+# - They work in any command, not just cd: ls ~proj, vim ~config/file.txt
+# - You can nest them: cd ~proj/myapp
+# - Use descriptive but short names (2-4 characters work well)
+
+# Add your custom named directories below:

--- a/zsh/inc.suffix-aliases.zsh
+++ b/zsh/inc.suffix-aliases.zsh
@@ -1,0 +1,90 @@
+# Suffix Aliases
+# Similar to regular aliases, but they run based on a file's suffix (extension).
+# This allows you to open a file with a configured command simply by typing
+# the filename.
+#
+# Usage: Just type the filename and press Enter. Zsh will open it with the
+#        associated command based on the file extension.
+#
+# Example: Type "README.md" and it will open in your configured viewer
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (7:38-9:22)
+
+# Markdown files - open with bat (if available) or cat
+if command -v bat &> /dev/null; then
+    alias -s md=bat
+    alias -s markdown=bat
+else
+    alias -s md=cat
+    alias -s markdown=cat
+fi
+
+# Text files - open in $EDITOR
+alias -s txt=$EDITOR
+
+# JSON files - open with jq (if available) or $EDITOR
+if command -v jq &> /dev/null; then
+    alias -s json='jq .'
+else
+    alias -s json=$EDITOR
+fi
+
+# YAML files - open in $EDITOR
+alias -s yaml=$EDITOR
+alias -s yml=$EDITOR
+
+# Source code files - open in $EDITOR
+alias -s go=$EDITOR
+alias -s rs=$EDITOR
+alias -s py=$EDITOR
+alias -s js=$EDITOR
+alias -s ts=$EDITOR
+alias -s jsx=$EDITOR
+alias -s tsx=$EDITOR
+alias -s c=$EDITOR
+alias -s cpp=$EDITOR
+alias -s h=$EDITOR
+alias -s java=$EDITOR
+alias -s rb=$EDITOR
+alias -s php=$EDITOR
+alias -s sh=$EDITOR
+alias -s zsh=$EDITOR
+alias -s bash=$EDITOR
+
+# Config files - open in $EDITOR
+alias -s conf=$EDITOR
+alias -s config=$EDITOR
+alias -s ini=$EDITOR
+alias -s toml=$EDITOR
+
+# HTML files - open in browser (xdg-open on Linux, open on macOS)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias -s html=open
+elif command -v xdg-open &> /dev/null; then
+    alias -s html=xdg-open
+fi
+
+# PDF files - open in default PDF viewer
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias -s pdf=open
+elif command -v xdg-open &> /dev/null; then
+    alias -s pdf=xdg-open
+fi
+
+# Image files - open in default image viewer
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    alias -s {png,jpg,jpeg,gif,bmp,svg}=open
+elif command -v xdg-open &> /dev/null; then
+    alias -s {png,jpg,jpeg,gif,bmp,svg}=xdg-open
+fi
+
+# Archive files - list contents
+if command -v unzip &> /dev/null; then
+    alias -s zip='unzip -l'
+fi
+
+if command -v tar &> /dev/null; then
+    alias -s {tar,tar.gz,tgz,tar.bz2,tbz2,tar.xz,txz}='tar -tvf'
+fi
+
+# Add your own custom suffix aliases below:

--- a/zsh/inc.undo.zsh
+++ b/zsh/inc.undo.zsh
@@ -1,0 +1,20 @@
+# Undo in Zsh Command Buffer
+# Zsh has an undo feature that can revert the last action taken in the command
+# buffer, useful for accidental deletions or changes.
+#
+# Usage: Press Ctrl + _ (Control and underscore) to undo
+#        The undo widget is already bound by default in Zsh
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (1:48-2:38)
+
+# Note: The undo widget is already available by default in Zsh
+# Default keybindings:
+#   - Ctrl + _ (Emacs mode)
+#   - u (vi command mode)
+#
+# You can also bind it to other keys if desired:
+# bindkey '^Z' undo
+# bindkey '^[u' undo  # Alt+u
+
+# For visibility, we'll ensure the default binding is set
+bindkey '^_' undo

--- a/zsh/inc.zmv.zsh
+++ b/zsh/inc.zmv.zsh
@@ -1,0 +1,59 @@
+# zmv - Advanced Move/Rename Command
+# An advanced move command for batch renaming or moving files using powerful
+# pattern matching. Think of it as a programmable mv command with regex support.
+#
+# Usage: zmv [options] pattern replacement
+#
+# Common options:
+#   -n  Dry run (show what would be done without doing it)
+#   -i  Interactive mode (ask before each move)
+#   -v  Verbose (show each move as it happens)
+#   -w  Enable wildcard mode (simpler syntax, no need for parentheses)
+#
+# Reference: https://www.youtube.com/watch?v=3fVAtaGhUyU (11:04-13:08)
+
+# Enable zmv
+autoload -Uz zmv
+
+# Examples:
+#
+# Rename .log files to .txt:
+#   zmv '(*).log' '$1.txt'
+#
+# Add prefix to all .jpg files:
+#   zmv '(*).jpg' 'photo-$1.jpg'
+#
+# Change case (lowercase to uppercase):
+#   zmv '(*)' '${(U)1}'
+#
+# With wildcard mode (-w), syntax is simpler:
+#   zmv -w '*.log' '*.txt'
+#   zmv -w '*.jpg' 'photo-*.jpg'
+#
+# Dry run first to see what will happen:
+#   zmv -n '(*).log' '$1.txt'
+#
+# Interactive mode for safety:
+#   zmv -i '(*).log' '$1.txt'
+
+# Also enable zcp and zln (copy and link equivalents)
+autoload -Uz zcp
+autoload -Uz zln
+
+# Convenience aliases
+alias zmv='zmv -v'    # Always be verbose by default
+alias zcp='zcp -v'    # Verbose copy
+alias zln='zln -v'    # Verbose link
+
+# Alternative: Create a wrapper for safer zmv (always dry-run first)
+# zmv-safe() {
+#     echo "Dry run:"
+#     zmv -n "$@"
+#     echo ""
+#     read "response?Proceed with these changes? [y/N] "
+#     if [[ "$response" =~ ^[Yy]$ ]]; then
+#         zmv "$@"
+#     else
+#         echo "Cancelled."
+#     fi
+# }


### PR DESCRIPTION
## Summary

Allows you to bookmark frequently used directories with short aliases for quick navigation or referencing in commands.

## What it achieves

- Create short, memorable aliases for long directory paths
- Works with any command, not just `cd`
- Supports tab completion
- Can be nested with subdirectories

## Zsh Configuration

```zsh
hash -d proj=~/Projects
hash -d docs=~/Documents
hash -d config=~/.config
```

**Usage:** `cd ~proj`, `ls ~docs`, `vim ~config/nvim/init.lua`

## Reference

- **Original video**: [10 Zsh Tips to Improve Productivity (13:08-14:04)](https://www.youtube.com/watch?v=3fVAtaGhUyU)

## Additional Applications & Inspiration

- [TIL Hashrocket: Shortcuts with hash -d in zsh](https://til.hashrocket.com/posts/xsavbhlrz4-shortcuts-with-hash-d-in-zsh)
- [Myelin Blog: The zsh named directory hash table](https://blog.myelin.ch/2018/12/14/named-directory-hash-table.html)
- [arp242.net: Some zshrc tricks](https://www.arp242.net/zshrc.html)
- [Vincent Bernat: Directory bookmarks with Zsh](https://vincent.bernat.ch/en/blog/2015-zsh-directory-bookmarks)
- [GitHub: jthat/zsh-namelink](https://github.com/jthat/zsh-namelink)
- [Effective Coder: wd ZSH Plugin](https://www.effective-coder.com/bookmark-your-favorite-directories-with-the-wd-zsh-plugin/)
- [GitHub: jocelynmallon/zshmarks](https://github.com/jocelynmallon/zshmarks)
- [Z-Shell: Navigation Tools](https://wiki.zshell.dev/ecosystem/plugins/zsh-navigation-tools)